### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ config.json
 {
     "auth": {
         "mastodon": {
-            // "account_id": "XXXX",
             // "timeout_ms": 60000;
             // "trusted_cert_fingerprints": ["XXXX"],
             "access_token": "XXXX",
@@ -22,12 +21,12 @@ config.json
             "source": {
                 "source_type": "rss",
                 // "append_name": true,
-                // "link_hash": false,
-                // "link_query": false,
+                // "item_limit": 10,
+                // "link_replacements": { "/\\?.*$/": "" },
                 "feeds": {
                     "RSS": "https://rss.example/feed.rss"
                 },
-                "item_limit": 10
+                "minutesToCheck": 10
             },
             "target": {
                 "target_type": "mastodon",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Mastodon Bot
 ============
 
+This bot can filter and post RSS items to a Mastodon account.
+
 config.json
 -----------
 
@@ -28,8 +30,9 @@ config.json
                 "item_limit": 10
             },
             "target": {
-                // "sensitive": false,
                 "target_type": "mastodon",
+                // "related_status_keywords": [ "search.example" ],
+                // "sensitive": false,
                 "signature": "#rssbot"
             }
         }

--- a/README.md
+++ b/README.md
@@ -8,20 +8,27 @@ config.json
 {
     "auth": {
         "mastodon": {
+            // "account_id": "XXXX",
+            // "timeout_ms": 60000;
+            // "trusted_cert_fingerprints": ["XXXX"],
             "access_token": "XXXX",
-            "api_url": "https://mastodon.social/api/v1/"
+            "api_url": "https://mastodon.example/api/v1/"
         }
     },
     "transforms": [
         {
             "source": {
                 "source_type": "rss",
+                // "append_name": true,
+                // "link_hash": false,
+                // "link_query": false,
                 "feeds": {
                     "RSS": "https://rss.example/feed.rss"
                 },
                 "item_limit": 10
             },
             "target": {
+                // "sensitive": false,
                 "target_type": "mastodon",
                 "signature": "#rssbot"
             }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,67 @@ Mastodon Bot
 
 This bot can filter and post RSS items to a Mastodon account.
 
-config.json
------------
+
+
+Configuration
+-------------
+
+The Bot gets set up by a JSON configuration file, which contain 2 sections.
+
+
+
+### `auth`
+
+In the `auth` section does the bot load the access tokens, which allows
+it to post new RSS items.
+
+
+
+#### `auth: mastodon`
+
+The `mastodon` section contains the authentication information for the Mastodon
+account to use. The authentication must be set up on the Development page of the
+Mastodon account settings.
+
+* `access_token`: The access token to the Mastodon account. The account should at
+  least allow `write:statuses`.
+* `api_url`: The URL to the Mastodon server of the account, followed by
+  `/api/v1/`.
+* `timeout_ms`: An alternative timeout to wait for a JSON response from the
+  Mastodon server.
+* `trusted_cert_fingerprints`: This will expect specific certificates instead of
+  the general ones of the operating system.
+
+
+
+### `transform`
+
+In the `transform` section does the bot load the single source to target
+relations.
+
+
+
+#### `transform: source`
+
+The `source` section contains the configuration to find new items to post.
+
+* `source_type`: This setting is required and defines the type of source. Only
+  `rss` is supported right now.
+
+
+
+### `transform: target`
+
+
+The `target` section contains the configuration to post new items.
+
+* `target_type`: This setting is required and defines the type of target. Only
+  `mastodon` is supported right now.
+
+
+
+Example: config.json
+--------------------
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ config.json
             "source": {
                 "source_type": "rss",
                 // "append_name": true,
+                // "check_updated_time": true,
                 // "item_limit": 10,
                 // "link_replacements": { "/\\?.*$/": "" },
+                // "minutes_to_check": 10,
                 "feeds": {
                     "RSS": "https://rss.example/feed.rss"
-                },
-                "minutesToCheck": 10
+                }
             },
             "target": {
                 "target_type": "mastodon",
-                // "related_status_keywords": [ "search.example" ],
                 // "sensitive": false,
                 "signature": "#rssbot"
             }

--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -8,6 +8,11 @@ Yargs(hideBin(process.argv))
         description: 'Path to config'
     });
 }, function (argv) {
-    Bot.Transformer.run(Bot.Config.load(argv.config));
+    Bot.Transformer
+        .run(Bot.Config.load(argv.config))
+        .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
 })
     .parse();

--- a/lib/Clients/Client.d.ts
+++ b/lib/Clients/Client.d.ts
@@ -5,8 +5,7 @@ export declare class Client {
     readonly config: Client.Config;
     readonly mode: ('source' | 'target');
     delay(milliseconds: number): Promise<void>;
-    getItems(sinceTimestamp: number): Promise<Array<Client.Item>>;
-    getTimestamp(): Promise<number>;
+    getItems(): Promise<Array<Client.Item>>;
     setItems(items: Array<Client.Item>): Promise<void>;
 }
 export declare namespace Client {

--- a/lib/Clients/Client.js
+++ b/lib/Clients/Client.js
@@ -46,14 +46,11 @@ export class Client {
     async delay(milliseconds) {
         return new Promise(resolve => setTimeout(resolve, milliseconds));
     }
-    async getItems(sinceTimestamp) {
-        throw new Error('Not implemented');
-    }
-    async getTimestamp() {
+    async getItems() {
         throw new Error('Not implemented');
     }
     async setItems(items) {
-        throw new Error('Not implemented');
+        throw new Error('Not implemented', { cause: items });
     }
 }
 /* *

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -6,7 +6,7 @@ export declare class MastodonClient extends Client {
     readonly config: MastodonClient.Config;
     protected mastodon: MastodonAPI.default;
     protected get(path: string, params?: Record<string, any>): Promise<any>;
-    getTimestamp(): Promise<number>;
+    getTimestamp(latestTimestampKeywords?: Array<string>): Promise<number>;
     protected post(path: string, params?: Record<string, any>): Promise<number>;
     setItems(items: Array<Client.Item>): Promise<void>;
 }
@@ -20,6 +20,7 @@ export declare namespace MastodonClient {
     }
     interface TargetConfig extends Client.TargetConfig {
         target_type: 'mastodon';
+        latestTimestampKeywords?: Array<string>;
         sensitive?: boolean;
         signature?: string;
     }

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -6,7 +6,6 @@ export declare class MastodonClient extends Client {
     readonly config: MastodonClient.Config;
     protected mastodon: MastodonAPI.default;
     protected get(path: string, params?: Record<string, any>): Promise<any>;
-    getTimestamp(): Promise<number>;
     protected post(path: string, params?: Record<string, any>): Promise<number>;
     setItems(items: Array<Client.Item>): Promise<void>;
 }

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -6,7 +6,7 @@ export declare class MastodonClient extends Client {
     readonly config: MastodonClient.Config;
     protected mastodon: MastodonAPI.default;
     protected get(path: string, params?: Record<string, any>): Promise<any>;
-    getTimestamp(latestTimestampKeywords?: Array<string>): Promise<number>;
+    getTimestamp(): Promise<number>;
     protected post(path: string, params?: Record<string, any>): Promise<number>;
     setItems(items: Array<Client.Item>): Promise<void>;
 }

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -18,7 +18,6 @@ export declare namespace MastodonClient {
     }
     interface TargetConfig extends Client.TargetConfig {
         target_type: 'mastodon';
-        related_status_keywords?: Array<string>;
         sensitive?: boolean;
         signature?: string;
     }

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -20,7 +20,7 @@ export declare namespace MastodonClient {
     }
     interface TargetConfig extends Client.TargetConfig {
         target_type: 'mastodon';
-        latestTimestampKeywords?: Array<string>;
+        related_status_keywords?: Array<string>;
         sensitive?: boolean;
         signature?: string;
     }

--- a/lib/Clients/MastodonClient.d.ts
+++ b/lib/Clients/MastodonClient.d.ts
@@ -11,7 +11,6 @@ export declare class MastodonClient extends Client {
 }
 export declare namespace MastodonClient {
     interface AuthConfig extends MastodonAPI.Config {
-        account_id?: number;
     }
     type Config = (SourceConfig | TargetConfig);
     interface SourceConfig extends Client.SourceConfig {

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -46,13 +46,25 @@ export class MastodonClient extends Client {
             this.mastodon.get(path, params, (err, data) => (err ? reject(err) : resolve(data)));
         });
     }
-    async getTimestamp() {
+    async getTimestamp(latestTimestampKeywords = []) {
+        const keywords = !!latestTimestampKeywords.length;
+        const limit = keywords ? '' : '?limit=1';
         const accountId = (this.authConfig.account_id ||
             (await this.get('accounts/verify_credentials')).id);
-        const status = ((await this.get(`accounts/${accountId}/statuses?limit=1`))
-            ?.pop());
-        return (status?.created_at ? Date.parse(status.created_at) :
-            new Date().getTime());
+        const statuses = await this.get(`accounts/${accountId}/statuses${limit}`);
+        let text;
+        for (const status of statuses) {
+            text = status.status;
+            if (keywords &&
+                text &&
+                !Utilities.includes(text, latestTimestampKeywords)) {
+                continue;
+            }
+            if (status.created_at) {
+                return Date.parse(status.created_at);
+            }
+        }
+        return new Date().getTime();
     }
     post(path, params = {}) {
         return new Promise((resolve, reject) => {

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -46,9 +46,11 @@ export class MastodonClient extends Client {
             this.mastodon.get(path, params, (err, data) => (err ? reject(err) : resolve(data)));
         });
     }
-    async getTimestamp(latestTimestampKeywords = []) {
+    async getTimestamp() {
+        const config = this.config;
+        const latestTimestampKeywords = (config.latestTimestampKeywords || []);
         const keywords = !!latestTimestampKeywords.length;
-        const limit = keywords ? '' : '?limit=1';
+        const limit = (keywords ? '' : '?limit=1');
         const accountId = (this.authConfig.account_id ||
             (await this.get('accounts/verify_credentials')).id);
         const statuses = await this.get(`accounts/${accountId}/statuses${limit}`);

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -73,17 +73,17 @@ export class MastodonClient extends Client {
         const signature = config.signature || '';
         const stdout = process.stdout;
         let delay;
-        stdout.write(`\nPosting ${items.length} item(s)`);
+        stdout.write(`Posting ${items.length} item(s)`);
         for (const item of items) {
             delay = await this.post('statuses', {
                 status: Utilities.assembleString((item.text || '').trim(), (item.link || signature ? '\n' : '') +
                     (item.link ? `\n${item.link}` : '') +
                     (signature ? `\n${signature}` : ''), 500)
             });
-            process.stdout.write('.');
+            stdout.write('.');
             await this.delay(delay);
         }
-        process.stdout.write('\n');
+        stdout.write('\n');
     }
 }
 /* *

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -7,6 +7,7 @@ import { createRequire as _createRequire } from "module";
 const __require = _createRequire(import.meta.url);
 import Client from './Client.js';
 const Mastodon = __require("mastodon-api");
+import Utilities from '../Utilities.js';
 /* *
  *
  *  Class
@@ -83,13 +84,9 @@ export class MastodonClient extends Client {
         stdout.write(`\nPosting ${items.length} item(s)`);
         for (const item of items) {
             delay = await this.post('statuses', {
-                status: ((item.text || '')
-                    .trim()
-                    .substring(0, 498 - (item.link || '').length - signature.length)
-                    + '\n'
-                    + item.link
-                    + '\n'
-                    + signature)
+                status: Utilities.assembleString((item.text || '').trim(), (item.link || signature ? '\n' : '') +
+                    (item.link ? `\n${item.link}` : '') +
+                    (signature ? `\n${signature}` : ''), 500)
             });
             process.stdout.write('.');
             await this.delay(delay);

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -46,30 +46,6 @@ export class MastodonClient extends Client {
             this.mastodon.get(path, params, (err, data) => (err ? reject(err) : resolve(data)));
         });
     }
-    async getTimestamp() {
-        const config = this.config;
-        const statusKeywords = (config.related_status_keywords || []);
-        const hasKeywords = !!statusKeywords.length;
-        const limit = (hasKeywords ? '' : '?limit=1');
-        const accountId = (this.authConfig.account_id ||
-            (await this.get('accounts/verify_credentials')).id);
-        const statuses = await this.get(`accounts/${accountId}/statuses${limit}`);
-        let timestamp = new Date().getTime();
-        let content;
-        for (const status of statuses) {
-            content = status.content;
-            if (status.created_at) {
-                timestamp = Date.parse(status.created_at);
-            }
-            if (hasKeywords &&
-                content &&
-                !Utilities.includes(content, statusKeywords)) {
-                continue;
-            }
-            break;
-        }
-        return timestamp;
-    }
     post(path, params = {}) {
         return new Promise((resolve, reject) => {
             this.mastodon.post(path, params, (err, data, response) => {

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -83,7 +83,7 @@ export class MastodonClient extends Client {
             stdout.write('.');
             await this.delay(delay);
         }
-        stdout.write('\n');
+        stdout.write(' - done.\n');
     }
 }
 /* *

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -70,12 +70,14 @@ export class MastodonClient extends Client {
             return;
         }
         const config = this.config;
+        const sensitive = config.sensitive;
         const signature = config.signature || '';
         const stdout = process.stdout;
         let delay;
         stdout.write(`Posting ${items.length} item(s)`);
         for (const item of items) {
             delay = await this.post('statuses', {
+                sensitive,
                 status: Utilities.assembleString((item.text || '').trim(), (item.link || signature ? '\n' : '') +
                     (item.link ? `\n${item.link}` : '') +
                     (signature ? `\n${signature}` : ''), 500)

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -61,10 +61,10 @@ export class MastodonClient extends Client {
                 }
                 const rateLimit = parseInt('0' + response.headers['x-ratelimit-remaining'], 10);
                 if (rateLimit) {
-                    resolve(60000 / rateLimit);
+                    resolve(300000 / rateLimit);
                 }
                 else {
-                    resolve(3000);
+                    resolve(6000);
                 }
             });
         });

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -58,17 +58,14 @@ export class MastodonClient extends Client {
         let content;
         for (const status of statuses) {
             content = status.content;
-            console.log(status);
             if (status.created_at) {
                 timestamp = Date.parse(status.created_at);
             }
             if (hasKeywords &&
                 content &&
                 !Utilities.includes(content, statusKeywords)) {
-                console.log('continue', timestamp);
                 continue;
             }
-            console.log('break', timestamp);
             break;
         }
         return timestamp;

--- a/lib/Clients/MastodonClient.js
+++ b/lib/Clients/MastodonClient.js
@@ -48,25 +48,30 @@ export class MastodonClient extends Client {
     }
     async getTimestamp() {
         const config = this.config;
-        const latestTimestampKeywords = (config.latestTimestampKeywords || []);
-        const keywords = !!latestTimestampKeywords.length;
-        const limit = (keywords ? '' : '?limit=1');
+        const statusKeywords = (config.related_status_keywords || []);
+        const hasKeywords = !!statusKeywords.length;
+        const limit = (hasKeywords ? '' : '?limit=1');
         const accountId = (this.authConfig.account_id ||
             (await this.get('accounts/verify_credentials')).id);
         const statuses = await this.get(`accounts/${accountId}/statuses${limit}`);
-        let text;
+        let timestamp = new Date().getTime();
+        let content;
         for (const status of statuses) {
-            text = status.status;
-            if (keywords &&
-                text &&
-                !Utilities.includes(text, latestTimestampKeywords)) {
+            content = status.content;
+            console.log(status);
+            if (status.created_at) {
+                timestamp = Date.parse(status.created_at);
+            }
+            if (hasKeywords &&
+                content &&
+                !Utilities.includes(content, statusKeywords)) {
+                console.log('continue', timestamp);
                 continue;
             }
-            if (status.created_at) {
-                return Date.parse(status.created_at);
-            }
+            console.log('break', timestamp);
+            break;
         }
-        return new Date().getTime();
+        return timestamp;
     }
     post(path, params = {}) {
         return new Promise((resolve, reject) => {

--- a/lib/Clients/RSSClient.d.ts
+++ b/lib/Clients/RSSClient.d.ts
@@ -7,10 +7,11 @@ export declare namespace RSSClient {
     interface SourceConfig extends Client.SourceConfig {
         source_type: 'rss';
         append_name?: boolean;
+        check_updated_time?: boolean;
         feeds: Record<string, string>;
         item_limit?: number;
         link_replacements?: Record<string, string>;
-        minutesToCheck?: number;
+        minutes_to_check?: number;
     }
     interface TargetConfig extends Client.TargetConfig {
         target_type: 'rss';

--- a/lib/Clients/RSSClient.d.ts
+++ b/lib/Clients/RSSClient.d.ts
@@ -1,16 +1,16 @@
 import Client from './Client.js';
 export declare class RSSClient extends Client {
-    getItems(sinceTimestamp: number): Promise<Array<Client.Item>>;
+    getItems(): Promise<Array<Client.Item>>;
 }
 export declare namespace RSSClient {
     type Config = (SourceConfig | TargetConfig);
     interface SourceConfig extends Client.SourceConfig {
         source_type: 'rss';
         append_name?: boolean;
-        item_limit?: number;
-        link_hash?: boolean;
-        link_query?: boolean;
         feeds: Record<string, string>;
+        item_limit?: number;
+        link_replacements?: Record<string, string>;
+        minutesToCheck?: number;
     }
     interface TargetConfig extends Client.TargetConfig {
         target_type: 'rss';

--- a/lib/Clients/RSSClient.d.ts
+++ b/lib/Clients/RSSClient.d.ts
@@ -8,6 +8,8 @@ export declare namespace RSSClient {
         source_type: 'rss';
         append_name?: boolean;
         item_limit?: number;
+        link_hash?: boolean;
+        link_query?: boolean;
         feeds: Record<string, string>;
     }
     interface TargetConfig extends Client.TargetConfig {

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -18,13 +18,14 @@ export class RSSClient extends Client {
      *  Functions
      *
      * */
-    async getItems(sinceTimestamp) {
+    async getItems() {
         if (this.mode !== 'source') {
             throw new Error('Client is not in source mode');
         }
         const allItems = [];
         const config = this.config;
         const feeds = config.feeds;
+        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 1000);
         const stdout = process.stdout;
         stdout.write(`\nSearch for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
         for (const feedName in feeds) {
@@ -50,8 +51,7 @@ export class RSSClient extends Client {
                     }
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
                     link = typeof link === 'object' ? link.$_href : link;
-                    link = config.link_query === false ? link.split('?')[0] : link;
-                    link = config.link_hash === false ? link.split('#')[0] : link;
+                    link = Utilities.replacePatterns(link, (config.link_replacements || {}));
                     let text = Utilities.trimSpaces(item.description || item.summary || '', true);
                     text = (item.title && text ?
                         Utilities.trimSpaces(item.title, true) + '\n\n' + text :

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -24,8 +24,9 @@ export class RSSClient extends Client {
         }
         const allItems = [];
         const config = this.config;
+        const checkUpdated = !!config.check_updated_time;
         const feeds = config.feeds;
-        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
+        const sinceTimestamp = (new Date().getTime() - (config.minutes_to_check || 10) * 60000);
         const stdout = process.stdout;
         stdout.write(`Searching for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
         for (const feedName in feeds) {
@@ -46,7 +47,9 @@ export class RSSClient extends Client {
                 let items = channel.item || channel.entry;
                 items = items instanceof Array ? items : [items];
                 for (const item of items) {
-                    const timestamp = Date.parse(item.pubDate || item.published);
+                    const timestamp = (checkUpdated ?
+                        Date.parse(item.updated || item.pubDate || item.published) :
+                        Date.parse(item.pubDate || item.published));
                     if (timestamp < sinceTimestamp) {
                         continue;
                     }

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -49,9 +49,9 @@ export class RSSClient extends Client {
                         continue;
                     }
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
-                    link = typeof link === 'string' ? link : link.$_href;
-                    link = config.link_query ? link : link.split('?')[0];
-                    link = config.link_hash ? link : link.split('#')[0];
+                    link = typeof link === 'object' ? link.$_href : link;
+                    link = config.link_query === false ? link.split('?')[0] : link;
+                    link = config.link_hash === false ? link.split('#')[0] : link;
                     let text = Utilities.trimSpaces(item.description || item.summary || '', true);
                     text = (item.title && text ?
                         Utilities.trimSpaces(item.title, true) + '\n\n' + text :

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -49,6 +49,8 @@ export class RSSClient extends Client {
                     }
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
                     link = typeof link === 'string' ? link : link.$_href;
+                    link = config.link_query ? link : link.split('?')[0];
+                    link = config.link_hash ? link : link.split('#')[0];
                     let text = (item.description || item.summary || item.title);
                     text = config.append_name ? config.append_name + '\n' + text : text;
                     allItems.push({

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -27,7 +27,7 @@ export class RSSClient extends Client {
         const feeds = config.feeds;
         const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
         const stdout = process.stdout;
-        stdout.write(`Search for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
+        stdout.write(`Searching for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
         for (const feedName in feeds) {
             stdout.write(`Checking ${feedName}`);
             const response = await fetch(feeds[feedName]);
@@ -69,7 +69,7 @@ export class RSSClient extends Client {
                     stdout.write('.');
                 }
             }
-            stdout.write('\n');
+            stdout.write(' - done.\n');
         }
         allItems.sort((a, b) => a.timestamp - b.timestamp);
         if (config.item_limit &&

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -49,7 +49,7 @@ export class RSSClient extends Client {
                     }
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
                     link = typeof link === 'string' ? link : link.$_href;
-                    let text = (item.description || item.summary);
+                    let text = (item.description || item.summary || item.title);
                     text = config.append_name ? config.append_name + '\n' + text : text;
                     allItems.push({
                         link,

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -6,6 +6,7 @@
 import * as XML from 'fast-xml-parser';
 import fetch from 'node-fetch';
 import Client from './Client.js';
+import Utilities from '../Utilities.js';
 /* *
  *
  *  Class
@@ -51,8 +52,13 @@ export class RSSClient extends Client {
                     link = typeof link === 'string' ? link : link.$_href;
                     link = config.link_query ? link : link.split('?')[0];
                     link = config.link_hash ? link : link.split('#')[0];
-                    let text = (item.description || item.summary || item.title);
-                    text = config.append_name ? config.append_name + '\n' + text : text;
+                    let text = Utilities.trimSpaces(item.description || item.summary || '', true);
+                    text = (item.title && text ?
+                        Utilities.trimSpaces(item.title, true) + '\n\n' + text :
+                        Utilities.trimSpaces(item.title || '', true) || text);
+                    text = (config.append_name && feedName ?
+                        Utilities.trimSpaces(feedName, true) + ': ' + text :
+                        text);
                     allItems.push({
                         link,
                         source_type: 'rss',

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -25,10 +25,11 @@ export class RSSClient extends Client {
         const allItems = [];
         const config = this.config;
         const feeds = config.feeds;
-        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 1000);
+        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
         const stdout = process.stdout;
-        stdout.write(`\nSearch for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
+        stdout.write(`Search for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
         for (const feedName in feeds) {
+            stdout.write(`Checking ${feedName}`);
             const response = await fetch(feeds[feedName]);
             const parser = new XML.XMLParser({
                 attributeNamePrefix: '$_',
@@ -65,7 +66,9 @@ export class RSSClient extends Client {
                         text,
                         timestamp
                     });
+                    stdout.write('.');
                 }
+                stdout.write('\n');
             }
         }
         allItems.sort((a, b) => a.timestamp - b.timestamp);

--- a/lib/Clients/RSSClient.js
+++ b/lib/Clients/RSSClient.js
@@ -68,8 +68,8 @@ export class RSSClient extends Client {
                     });
                     stdout.write('.');
                 }
-                stdout.write('\n');
             }
+            stdout.write('\n');
         }
         allItems.sort((a, b) => a.timestamp - b.timestamp);
         if (config.item_limit &&

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -100,10 +100,10 @@ export class Transformer {
                 continue;
             }
             for (const pattern in replacements) {
-                if (pattern.length > 3 &&
+                if (pattern.length > 2 &&
                     pattern.startsWith('/') &&
                     pattern.endsWith('/')) {
-                    text = text.replace(new RegExp(pattern.substring(1, pattern.length - 2), 'gsu'), replacements[pattern]);
+                    text = text.replace(new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'), replacements[pattern]);
                 }
                 else {
                     text = text

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -100,7 +100,16 @@ export class Transformer {
                 continue;
             }
             for (const pattern in replacements) {
-                text = text.split(pattern).join(replacements[pattern]);
+                if (pattern.length > 3 &&
+                    pattern.startsWith('/') &&
+                    pattern.endsWith('/')) {
+                    text = text.replace(new RegExp(pattern.substring(1, pattern.length - 2), 'gsu'), replacements[pattern]);
+                }
+                else {
+                    text = text
+                        .split(pattern)
+                        .join(replacements[pattern]);
+                }
             }
             filteredItems.push({
                 ...item,

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -4,6 +4,7 @@
  *
  * */
 import Client from './Clients/Client.js';
+import Utilities from './Utilities.js';
 /* *
  *
  *  Class
@@ -99,18 +100,7 @@ export class Transformer {
             if (negativesCounter > positivesCounter) {
                 continue;
             }
-            for (const pattern in replacements) {
-                if (pattern.length > 2 &&
-                    pattern.startsWith('/') &&
-                    pattern.endsWith('/')) {
-                    text = text.replace(new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'), replacements[pattern]);
-                }
-                else {
-                    text = text
-                        .split(pattern)
-                        .join(replacements[pattern]);
-                }
-            }
+            Utilities.replacePatterns(text, replacements);
             filteredItems.push({
                 ...item,
                 text
@@ -121,7 +111,7 @@ export class Transformer {
     async transform() {
         const sourceClient = this.sourceClient;
         const targetClient = this.targetClient;
-        await targetClient.setItems(this.filter(await sourceClient.getItems(await targetClient.getTimestamp())));
+        await targetClient.setItems(this.filter(await sourceClient.getItems()));
     }
 }
 /* *

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -100,7 +100,7 @@ export class Transformer {
             if (negativesCounter > positivesCounter) {
                 continue;
             }
-            Utilities.replacePatterns(text, replacements);
+            text = Utilities.replacePatterns(text, replacements);
             filteredItems.push({
                 ...item,
                 text

--- a/lib/Utilities.d.ts
+++ b/lib/Utilities.d.ts
@@ -1,7 +1,9 @@
 declare function assembleString(text: string, addition: string, maxLength: number): string;
+declare function includes(text: string, searchTerms: Array<string>): boolean;
 declare function trimSpaces(text: string, removeBreaks?: boolean): string;
 export declare const Utilities: {
     assembleString: typeof assembleString;
+    includes: typeof includes;
     trimSpaces: typeof trimSpaces;
 };
 export default Utilities;

--- a/lib/Utilities.d.ts
+++ b/lib/Utilities.d.ts
@@ -1,0 +1,5 @@
+declare function assembleString(text: string, addition: string, maxLength: number): string;
+export declare const Utilities: {
+    assembleString: typeof assembleString;
+};
+export default Utilities;

--- a/lib/Utilities.d.ts
+++ b/lib/Utilities.d.ts
@@ -1,5 +1,7 @@
 declare function assembleString(text: string, addition: string, maxLength: number): string;
+declare function trimSpaces(text: string, removeBreaks?: boolean): string;
 export declare const Utilities: {
     assembleString: typeof assembleString;
+    trimSpaces: typeof trimSpaces;
 };
 export default Utilities;

--- a/lib/Utilities.d.ts
+++ b/lib/Utilities.d.ts
@@ -1,9 +1,11 @@
 declare function assembleString(text: string, addition: string, maxLength: number): string;
 declare function includes(text: string, searchTerms: Array<string>): boolean;
+declare function replacePatterns(text: string, replacementPatterns: Record<string, string>): string;
 declare function trimSpaces(text: string, removeBreaks?: boolean): string;
 export declare const Utilities: {
     assembleString: typeof assembleString;
     includes: typeof includes;
+    replacePatterns: typeof replacePatterns;
     trimSpaces: typeof trimSpaces;
 };
 export default Utilities;

--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -25,6 +25,23 @@ function includes(text, searchTerms) {
     }
     return false;
 }
+function replacePatterns(text, replacementPatterns) {
+    let replacement;
+    for (const pattern in replacementPatterns) {
+        replacement = replacementPatterns[pattern];
+        if (pattern.length > 2 &&
+            pattern.startsWith('/') &&
+            pattern.endsWith('/')) {
+            text = text.replace(new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'), replacement);
+        }
+        else {
+            text = text
+                .split(pattern)
+                .join(replacement);
+        }
+    }
+    return text;
+}
 function trimSpaces(text, removeBreaks) {
     if (removeBreaks) {
         text = text.replace(BREAKS_REGEXP, ' ');
@@ -39,6 +56,7 @@ function trimSpaces(text, removeBreaks) {
 export const Utilities = {
     assembleString,
     includes,
+    replacePatterns,
     trimSpaces
 };
 export default Utilities;

--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -1,5 +1,12 @@
 /* *
  *
+ *  Constants
+ *
+ * */
+const BREAKS_REGEXP = /[\n\r]+/gu;
+const SPACES_REGEXP = /\s+/gu;
+/* *
+ *
  *  Functions
  *
  * */
@@ -10,12 +17,19 @@ function assembleString(text, addition, maxLength) {
     text = text.substring(0, maxLength - addition.length - 3) + '...';
     return text + addition;
 }
+function trimSpaces(text, removeBreaks) {
+    if (removeBreaks) {
+        text = text.replace(BREAKS_REGEXP, ' ');
+    }
+    return text.replace(SPACES_REGEXP, ' ').trim();
+}
 /* *
  *
  *  Default Export
  *
  * */
 export const Utilities = {
-    assembleString
+    assembleString,
+    trimSpaces
 };
 export default Utilities;

--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -1,0 +1,21 @@
+/* *
+ *
+ *  Functions
+ *
+ * */
+function assembleString(text, addition, maxLength) {
+    if (text.length + addition.length <= maxLength) {
+        return text + addition;
+    }
+    text = text.substring(0, maxLength - addition.length - 3) + '...';
+    return text + addition;
+}
+/* *
+ *
+ *  Default Export
+ *
+ * */
+export const Utilities = {
+    assembleString
+};
+export default Utilities;

--- a/lib/Utilities.js
+++ b/lib/Utilities.js
@@ -17,6 +17,14 @@ function assembleString(text, addition, maxLength) {
     text = text.substring(0, maxLength - addition.length - 3) + '...';
     return text + addition;
 }
+function includes(text, searchTerms) {
+    for (const term of searchTerms) {
+        if (text.includes(term)) {
+            return true;
+        }
+    }
+    return false;
+}
 function trimSpaces(text, removeBreaks) {
     if (removeBreaks) {
         text = text.replace(BREAKS_REGEXP, ' ');
@@ -30,6 +38,7 @@ function trimSpaces(text, removeBreaks) {
  * */
 export const Utilities = {
     assembleString,
+    includes,
     trimSpaces
 };
 export default Utilities;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,4 @@
 export * from './Clients/index.js';
 export * from './Config.js';
 export * from './Transformer.js';
+export * from './Utilities.js';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 export * from './Clients/index.js';
 export * from './Config.js';
 export * from './Transformer.js';
+export * from './Utilities.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mastodon-bot",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "mastodon-bot",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
                 "fast-xml-parser": "^4.0.11",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
     "private": true,
+
     "author": "Sophie Bremer",
     "description": "Mastodon bot",
     "license": "MIT",
     "name": "mastodon-bot",
     "type": "module",
-    "version": "0.1.0",
+    "version": "1.0.0",
 
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -13,7 +13,12 @@ Yargs(hideBin(process.argv))
             });
         },
         function (argv) {
-            Bot.Transformer.run(Bot.Config.load(argv.config));
+            Bot.Transformer
+                .run(Bot.Config.load(argv.config))
+                .catch((e) => {
+                    console.error(e);
+                    process.exit(1);
+                });
         }
     )
     .parse();

--- a/src/Clients/Client.ts
+++ b/src/Clients/Client.ts
@@ -72,20 +72,14 @@ export class Client {
         return new Promise(resolve => setTimeout(resolve, milliseconds));
     }
 
-    public async getItems(
-        sinceTimestamp: number
-    ): Promise<Array<Client.Item>> {
-        throw new Error('Not implemented');
-    }
-
-    public async getTimestamp(): Promise<number> {
+    public async getItems(): Promise<Array<Client.Item>> {
         throw new Error('Not implemented');
     }
 
     public async setItems(
         items: Array<Client.Item>
     ): Promise<void> {
-        throw new Error('Not implemented');
+        throw new Error('Not implemented', { cause: items });
     }
 
 }

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -68,41 +68,6 @@ export class MastodonClient extends Client {
         });
     }
 
-    public async getTimestamp(): Promise<number> {
-        const config = this.config as MastodonClient.TargetConfig;
-        const statusKeywords = (config.related_status_keywords || []);
-        const hasKeywords = !!statusKeywords.length;
-        const limit = (hasKeywords ? '' : '?limit=1');
-        const accountId = (
-            this.authConfig.account_id ||
-            (await this.get('accounts/verify_credentials')).id
-        );
-        const statuses = await this.get(`accounts/${accountId}/statuses${limit}`);
-
-        let timestamp = new Date().getTime();
-        let content: string;
-
-        for (const status of statuses) {
-            content = status.content;
-
-            if (status.created_at) {
-                timestamp = Date.parse(status.created_at);
-            }
-
-            if (
-                hasKeywords &&
-                content &&
-                !Utilities.includes(content, statusKeywords)
-            ) {
-                continue;
-            }
-
-            break;
-        }
-
-        return timestamp;
-    }
-
     protected post(
         path: string,
         params: Record<string, any> = {}
@@ -182,7 +147,7 @@ export namespace MastodonClient {
      * */
 
     export interface AuthConfig extends MastodonAPI.Config {
-        account_id?: number
+        // nothing to add
     }
 
     export type Config = (SourceConfig|TargetConfig);

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -103,6 +103,7 @@ export class MastodonClient extends Client {
         }
 
         const config = this.config as MastodonClient.TargetConfig;
+        const sensitive = config.sensitive;
         const signature = config.signature || '';
         const stdout = process.stdout;
 
@@ -113,6 +114,7 @@ export class MastodonClient extends Client {
         for (const item of items) {
 
             delay = await this.post('statuses', {
+                sensitive,
                 status: Utilities.assembleString(
                     (item.text || '').trim(),
                     (item.link || signature ? '\n' : '') +

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -108,7 +108,7 @@ export class MastodonClient extends Client {
 
         let delay: number;
 
-        stdout.write(`\nPosting ${items.length} item(s)`);
+        stdout.write(`Posting ${items.length} item(s)`);
 
         for (const item of items) {
 
@@ -122,12 +122,12 @@ export class MastodonClient extends Client {
                 )
             });
 
-            process.stdout.write('.');
+            stdout.write('.');
 
             await this.delay(delay);
         }
 
-        process.stdout.write('\n');
+        stdout.write('\n');
     }
 
 }

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -83,7 +83,7 @@ export class MastodonClient extends Client {
         let content: string;
 
         for (const status of statuses) {
-            content = status.content;console.log(status);
+            content = status.content;
 
             if (status.created_at) {
                 timestamp = Date.parse(status.created_at);
@@ -94,11 +94,9 @@ export class MastodonClient extends Client {
                 content &&
                 !Utilities.includes(content, statusKeywords)
             ) {
-                console.log('continue', timestamp);
                 continue;
             }
 
-            console.log('break', timestamp);
             break;
         }
 

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -68,11 +68,11 @@ export class MastodonClient extends Client {
         });
     }
 
-    public async getTimestamp(
-        latestTimestampKeywords: Array<string> = []
-    ): Promise<number> {
+    public async getTimestamp(): Promise<number> {
+        const config = this.config as MastodonClient.TargetConfig;
+        const latestTimestampKeywords = (config.latestTimestampKeywords || []);
         const keywords = !!latestTimestampKeywords.length;
-        const limit = keywords ? '' : '?limit=1';
+        const limit = (keywords ? '' : '?limit=1');
         const accountId = (
             this.authConfig.account_id ||
             (await this.get('accounts/verify_credentials')).id

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -8,6 +8,7 @@ import type * as MastodonAPI from 'mastodon-api';
 
 import Client from './Client.js';
 import Mastodon = require('mastodon-api');
+import Utilities from '../Utilities.js';
 
 /* *
  *
@@ -128,14 +129,12 @@ export class MastodonClient extends Client {
         for (const item of items) {
 
             delay = await this.post('statuses', {
-                status: (
-                    (item.text || '')
-                        .trim()
-                        .substring(0, 498 - (item.link || '').length - signature.length)
-                    + '\n'
-                    + item.link
-                    + '\n'
-                    + signature
+                status: Utilities.assembleString(
+                    (item.text || '').trim(),
+                    (item.link || signature ? '\n' : '') +
+                    (item.link ? `\n${item.link}` : '') +
+                    (signature ? `\n${signature}` : ''),
+                    500
                 )
             });
 

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -127,7 +127,7 @@ export class MastodonClient extends Client {
             await this.delay(delay);
         }
 
-        stdout.write('\n');
+        stdout.write(' - done.\n');
     }
 
 }

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -96,10 +96,10 @@ export class MastodonClient extends Client {
                 const rateLimit = parseInt('0' + response.headers['x-ratelimit-remaining'], 10);
 
                 if (rateLimit) {
-                    resolve(60000 / rateLimit);
+                    resolve(300000 / rateLimit);
                 }
                 else {
-                    resolve(3000);
+                    resolve(6000);
                 }
             }); 
         });

--- a/src/Clients/MastodonClient.ts
+++ b/src/Clients/MastodonClient.ts
@@ -158,7 +158,6 @@ export namespace MastodonClient {
 
     export interface TargetConfig extends Client.TargetConfig {
         target_type: 'mastodon';
-        related_status_keywords?: Array<string>;
         sensitive?: boolean;
         signature?: string;
     }

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -67,7 +67,7 @@ export class RSSClient extends Client {
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
                     link = typeof link === 'string' ? link : link.$_href;
 
-                    let text = (item.description || item.summary);
+                    let text = (item.description || item.summary || item.title);
                     text = config.append_name ? config.append_name + '\n' + text : text;
 
                     allItems.push({

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -7,6 +7,7 @@
 import * as XML from 'fast-xml-parser';
 import fetch from 'node-fetch';
 import Client from './Client.js';
+import Utilities from '../Utilities.js';
 
 /* *
  *
@@ -69,8 +70,20 @@ export class RSSClient extends Client {
                     link = config.link_query ? link : link.split('?')[0];
                     link = config.link_hash ? link : link.split('#')[0];
 
-                    let text = (item.description || item.summary || item.title);
-                    text = config.append_name ? config.append_name + '\n' + text : text;
+                    let text = Utilities.trimSpaces(
+                        item.description || item.summary || '',
+                        true
+                    );
+                    text = (
+                        item.title && text ?
+                            Utilities.trimSpaces(item.title, true) + '\n\n' + text :
+                            Utilities.trimSpaces(item.title || '', true) || text
+                    );
+                    text = (
+                        config.append_name && feedName ?
+                            Utilities.trimSpaces(feedName, true) + ': ' + text :
+                            text
+                    );
 
                     allItems.push({
                         link,

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -94,9 +94,9 @@ export class RSSClient extends Client {
 
                     stdout.write('.');
                 }
-
-                stdout.write('\n');
             }
+
+            stdout.write('\n');
         }
 
         allItems.sort((a, b) => a.timestamp - b.timestamp);

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -66,9 +66,9 @@ export class RSSClient extends Client {
                     }
 
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
-                    link = typeof link === 'string' ? link : link.$_href;
-                    link = config.link_query ? link : link.split('?')[0];
-                    link = config.link_hash ? link : link.split('#')[0];
+                    link = typeof link === 'object' ? link.$_href : link;
+                    link = config.link_query === false ? link.split('?')[0] : link;
+                    link = config.link_hash === false ? link.split('#')[0] : link;
 
                     let text = Utilities.trimSpaces(
                         item.description || item.summary || '',

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -66,6 +66,8 @@ export class RSSClient extends Client {
 
                     let link = (item.link instanceof Array ? item.link[0] : item.link);
                     link = typeof link === 'string' ? link : link.$_href;
+                    link = config.link_query ? link : link.split('?')[0];
+                    link = config.link_hash ? link : link.split('#')[0];
 
                     let text = (item.description || item.summary || item.title);
                     text = config.append_name ? config.append_name + '\n' + text : text;
@@ -114,6 +116,8 @@ export namespace RSSClient {
         source_type: 'rss';
         append_name?: boolean;
         item_limit?: number;
+        link_hash?: boolean;
+        link_query?: boolean;
         feeds: Record<string, string>;
     }
 

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -35,7 +35,7 @@ export class RSSClient extends Client {
         const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
         const stdout = process.stdout;
 
-        stdout.write(`Search for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
+        stdout.write(`Searching for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
 
         for (const feedName in feeds) {
             stdout.write(`Checking ${feedName}`);
@@ -96,7 +96,7 @@ export class RSSClient extends Client {
                 }
             }
 
-            stdout.write('\n');
+            stdout.write(' - done.\n');
         }
 
         allItems.sort((a, b) => a.timestamp - b.timestamp);

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -31,8 +31,9 @@ export class RSSClient extends Client {
 
         const allItems: Array<Client.Item> = [];
         const config = this.config as RSSClient.SourceConfig;
+        const checkUpdated = !!config.check_updated_time;
         const feeds = config.feeds;
-        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
+        const sinceTimestamp = (new Date().getTime() - (config.minutes_to_check || 10) * 60000);
         const stdout = process.stdout;
 
         stdout.write(`Searching for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
@@ -60,7 +61,11 @@ export class RSSClient extends Client {
                 items = items instanceof Array ? items : [items];
 
                 for (const item of items) {
-                    const timestamp = Date.parse(item.pubDate || item.published);
+                    const timestamp = (
+                        checkUpdated ?
+                            Date.parse(item.updated || item.pubDate || item.published) :
+                            Date.parse(item.pubDate || item.published)
+                    );
 
                     if (timestamp < sinceTimestamp) {
                         continue;
@@ -132,10 +137,11 @@ export namespace RSSClient {
     export interface SourceConfig extends Client.SourceConfig {
         source_type: 'rss';
         append_name?: boolean;
+        check_updated_time?: boolean;
         feeds: Record<string, string>;
         item_limit?: number;
         link_replacements?: Record<string, string>;
-        minutesToCheck?: number;
+        minutes_to_check?: number;
     }
 
     export interface TargetConfig extends Client.TargetConfig {

--- a/src/Clients/RSSClient.ts
+++ b/src/Clients/RSSClient.ts
@@ -32,12 +32,14 @@ export class RSSClient extends Client {
         const allItems: Array<Client.Item> = [];
         const config = this.config as RSSClient.SourceConfig;
         const feeds = config.feeds;
-        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 1000);
+        const sinceTimestamp = (new Date().getTime() - (config.minutesToCheck || 10) * 60000);
         const stdout = process.stdout;
 
-        stdout.write(`\nSearch for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
+        stdout.write(`Search for new items since ${new Date(sinceTimestamp).toUTCString()}\n`);
 
         for (const feedName in feeds) {
+            stdout.write(`Checking ${feedName}`);
+
             const response = await fetch(feeds[feedName]);
             const parser = new XML.XMLParser({
                 attributeNamePrefix: '$_',
@@ -89,7 +91,11 @@ export class RSSClient extends Client {
                         text,
                         timestamp
                     });
+
+                    stdout.write('.');
                 }
+
+                stdout.write('\n');
             }
         }
 

--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -149,7 +149,7 @@ export class Transformer {
                 continue;
             }
 
-            Utilities.replacePatterns(text, replacements);
+            text = Utilities.replacePatterns(text, replacements);
 
             filteredItems.push({
                 ...item,

--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -149,7 +149,21 @@ export class Transformer {
             }
 
             for (const pattern in replacements) {
-                text = text.split(pattern).join(replacements[pattern]);
+                if (
+                    pattern.length > 3 &&
+                    pattern.startsWith('/') &&
+                    pattern.endsWith('/')
+                ) {
+                    text = text.replace(
+                        new RegExp(pattern.substring(1, pattern.length - 2), 'gsu'),
+                        replacements[pattern]
+                    );
+                }
+                else {
+                    text = text
+                        .split(pattern)
+                        .join(replacements[pattern]);
+                }
             }
 
             filteredItems.push({

--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -6,6 +6,7 @@
 
 import Client from './Clients/Client.js';
 import Config from './Config.js';
+import Utilities from './Utilities.js';
 
 /* *
  *
@@ -148,23 +149,7 @@ export class Transformer {
                 continue;
             }
 
-            for (const pattern in replacements) {
-                if (
-                    pattern.length > 2 &&
-                    pattern.startsWith('/') &&
-                    pattern.endsWith('/')
-                ) {
-                    text = text.replace(
-                        new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'),
-                        replacements[pattern]
-                    );
-                }
-                else {
-                    text = text
-                        .split(pattern)
-                        .join(replacements[pattern]);
-                }
-            }
+            Utilities.replacePatterns(text, replacements);
 
             filteredItems.push({
                 ...item,
@@ -179,13 +164,7 @@ export class Transformer {
         const sourceClient = this.sourceClient;
         const targetClient = this.targetClient;
 
-        await targetClient.setItems(
-            this.filter(
-                await sourceClient.getItems(
-                    await targetClient.getTimestamp()
-                )
-            )
-        );
+        await targetClient.setItems(this.filter(await sourceClient.getItems()));
     }
 
 }

--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -150,12 +150,12 @@ export class Transformer {
 
             for (const pattern in replacements) {
                 if (
-                    pattern.length > 3 &&
+                    pattern.length > 2 &&
                     pattern.startsWith('/') &&
                     pattern.endsWith('/')
                 ) {
                     text = text.replace(
-                        new RegExp(pattern.substring(1, pattern.length - 2), 'gsu'),
+                        new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'),
                         replacements[pattern]
                     );
                 }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,5 +1,15 @@
 /* *
  *
+ *  Constants
+ *
+ * */
+
+const BREAKS_REGEXP = /[\n\r]+/gu;
+
+const SPACES_REGEXP = /\s+/gu;
+
+/* *
+ *
  *  Functions
  *
  * */
@@ -19,6 +29,18 @@ function assembleString(
     return text + addition;
 }
 
+function trimSpaces(
+    text: string,
+    removeBreaks?: boolean
+) {
+
+    if (removeBreaks) {
+        text = text.replace(BREAKS_REGEXP, ' ');
+    }
+
+    return text.replace(SPACES_REGEXP, ' ').trim();
+}
+
 /* *
  *
  *  Default Export
@@ -26,7 +48,8 @@ function assembleString(
  * */
 
 export const Utilities = {
-    assembleString
+    assembleString,
+    trimSpaces
 };
 
 export default Utilities;

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -29,6 +29,20 @@ function assembleString(
     return text + addition;
 }
 
+function includes(
+    text: string,
+    searchTerms: Array<string>
+): boolean {
+
+    for (const term of searchTerms) {
+        if (text.includes(term)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function trimSpaces(
     text: string,
     removeBreaks?: boolean
@@ -49,6 +63,7 @@ function trimSpaces(
 
 export const Utilities = {
     assembleString,
+    includes,
     trimSpaces
 };
 

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,0 +1,32 @@
+/* *
+ *
+ *  Functions
+ *
+ * */
+
+function assembleString(
+    text: string,
+    addition: string,
+    maxLength: number
+): string {
+
+    if (text.length + addition.length <= maxLength) {
+        return text + addition;
+    }
+
+    text = text.substring(0, maxLength - addition.length - 3) + '...';
+
+    return text + addition;
+}
+
+/* *
+ *
+ *  Default Export
+ *
+ * */
+
+export const Utilities = {
+    assembleString
+};
+
+export default Utilities;

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -43,6 +43,35 @@ function includes(
     return false;
 }
 
+function replacePatterns(
+    text: string,
+    replacementPatterns: Record<string, string>
+): string {
+    let replacement: string;
+
+    for (const pattern in replacementPatterns) {
+        replacement = replacementPatterns[pattern];
+
+        if (
+            pattern.length > 2 &&
+            pattern.startsWith('/') &&
+            pattern.endsWith('/')
+        ) {
+            text = text.replace(
+                new RegExp(pattern.substring(1, pattern.length - 1), 'gsu'),
+                replacement
+            );
+        }
+        else {
+            text = text
+                .split(pattern)
+                .join(replacement);
+        }
+    }
+
+    return text;
+}
+
 function trimSpaces(
     text: string,
     removeBreaks?: boolean
@@ -64,6 +93,7 @@ function trimSpaces(
 export const Utilities = {
     assembleString,
     includes,
+    replacePatterns,
     trimSpaces
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './Clients/index.js';
 export * from './Config.js';
 export * from './Transformer.js';
+export * from './Utilities.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -64,6 +64,7 @@
     // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    "noEmitOnError": true,
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */


### PR DESCRIPTION
- Added "..." to reduced text
- Added keyword filter for related Mastodon statuses: `"related_status_keywords": [ "search.example" ]`
- Added RSS item title as prefix
- Added trim options for RSS links: `"link_hash": (TRUE|false)` `"link_query": (TRUE|false)`
- Added RegExp support for replacements: `"replacements": { "/a(b)c/": "$1" }`
- Improved Mastodon limits
- Improved RSS text structure